### PR TITLE
Allow for videos without thumbnails.

### DIFF
--- a/src/components/Dialog.spec.tsx
+++ b/src/components/Dialog.spec.tsx
@@ -17,7 +17,7 @@ describe('Dialog component', () => {
         { id: 'abcd', name: '2. Folder Name' },
       ] as BrightcoveFolder[])
       .get('/folders/abcd/videos').reply(200, [
-        { id: '1', name: '1. Video Name', description: '1. Description', images: { thumbnail: { src: 'https://example.com/image.png' } } },
+        { id: '1', name: '1. Video Name', description: '1. Description', images: {} },
         { id: '2', name: '2. Video Name', description: '2. Description', images: { thumbnail: { src: 'https://example.com/image.png' } } },
       ] as BrightcoveVideo[])
   })

--- a/src/components/Dialog.tsx
+++ b/src/components/Dialog.tsx
@@ -104,7 +104,7 @@ const Dialog = ({ sdk }: DialogProps) => {
                   className={css`cursor: pointer;`}
                   title={video.name}
                   description={video.description}
-                  thumbnailUrl={video.images.thumbnail.src}
+                  thumbnailUrl={video.images.thumbnail?.src}
                   onClick={() => sdk.close(video)}
                 />
               ))


### PR DESCRIPTION
It's possible for a video to not have a thumbnail - it may not have completed encoding, or may be a live video that has not yet had a thumbnail added. This will cause an error when mapping videos to items. 

This change allows for the thumbnail to be optionally present so that the list can load. 